### PR TITLE
fix(single_thread): 修复单线程omc以及mod对象复用问题

### DIFF
--- a/example/example_config.json
+++ b/example/example_config.json
@@ -20,7 +20,7 @@
         "step_size": 1.0,
         "max_workers": 4,
         "keep_temp_files": false,
-        "concurrent": true
+        "concurrent": false
     },
     "simulation_parameters": {
         "blanket.T": [6, 12, 18],

--- a/tricys/utils/decorators_utils.py
+++ b/tricys/utils/decorators_utils.py
@@ -1,0 +1,19 @@
+'''A collection of useful decorators.'''
+import time
+import logging
+import functools
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+def record_time(func):
+    """A decorator to print the time it takes for a function to execute."""
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        start_time = time.perf_counter()
+        result = func(*args, **kwargs)
+        end_time = time.perf_counter()
+        run_time = end_time - start_time
+        logger.info(f"Finished '{func.__name__}' in {run_time:.4f} secs")
+        return result
+    return wrapper


### PR DESCRIPTION
@zxkjack123 @Valtro1s 

Closes https://github.com/asipp-neutronics/tricys/issues/25

### 修复思路
1. 在config.json中修改`"concurrent":false`，默认设置单线程

2. 新建_run_sequential_sweep函数处理单线程批量扫描仿真

3. 新增record_time装饰器统计多线程与单线程运行时间

### 测试结果

多线程运行时间：**35.6secs**，多线程初始化omc以及mod对象每次都会加载模型.mo文件，磁盘IO时间较慢
```
2025-08-22 08:29:46,385 - tricys.utils.decorators_utils - INFO - Finished 'run_simulation' in 35.6054 secs
```
单线程运行时间：**10.06sec**，单线程只加载一次.mo文件，获取建议单线程运行扫描仿真，修改`"concurrent":false`
```
2025-08-22 08:28:54,974 - tricys.utils.decorators_utils - INFO - Finished 'run_simulation' in 10.0631 secs
```
