### PR TITLE
chore: Set up pre-commit hook checks in Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,9 +37,6 @@ example/log/
 example/results/
 example/temp/
 
-# Normalize all line endings to LF
-* text=auto eol=lf
-
 # Ignore all contents in the example_aspenbkp folder
 example/example_aspenbkp/*
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+repos:
+-   repo: local
+    hooks:
+    -   id: check-dirty-py
+        name: Check for unstaged changes and untracked files
+        entry: python script/check_dirty.py
+        language: python
+        stages: [pre-commit]
+        always_run: true
+    -   id: black
+        name: black
+        entry: black
+        language: system
+        types: [python]
+        files: ^(tricys/|test/)
+    -   id: ruff
+        name: ruff
+        entry: ruff check --fix
+        language: system
+        types: [python]
+        files: ^(tricys/|test/)

--- a/Makefile.bat
+++ b/Makefile.bat
@@ -14,6 +14,8 @@ REM   lint          Check code style and potential errors (report only, do not m
 REM   format        Automatically format and repair code.
 REM   check         Combine commands: format first, then check to make sure the codebase is clean.
 REM   test          Perform one-click tests.
+REM   uninstall     Uninstall the project.
+REM   reinstall     Re-install the project (clean and install).
 REM   help          Show this help message.
 REM ------------------------------------------------------------------------------
 
@@ -38,6 +40,8 @@ echo   lint          Check code style and potential errors (report only, do not 
 echo   format        Automatically format and repair code.
 echo   check         Combine commands: format first, then check to make sure the codebase is clean.
 echo   test          Perform one-click tests.
+echo   uninstall     Uninstall the project.
+echo   reinstall     Re-install the project (uninstall , clean and install).
 echo   help          Show this help message.
 goto :eof
 
@@ -52,12 +56,14 @@ goto :eof
 :dev-install
 echo --^> Installing project with development dependencies...
 call pip install -e ".[dev]"
+call pre-commit install
 echo --^> Development installation complete.
 goto :eof
 
 :win-install
 echo --^> Installing project with development dependencies...
 call pip install -e ".[win]"
+call pre-commit install
 echo --^> Development installation complete.
 goto :eof
 
@@ -117,6 +123,22 @@ goto :eof
 :test
 echo --^> Pytest Project...
 call pytest -v test\.
+goto :eof
+
+
+:uninstall
+echo --^> Uninstalling project...
+call pip uninstall tricys -y
+echo --^> Uninstallation complete.
+goto :eof
+
+
+:reinstall
+echo --^> Re-installing project...
+call :uninstall
+call :clean
+call :win-install
+echo --^> Re-installation complete.
 goto :eof
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,14 +38,16 @@ tricys = "tricys.simulation:main"
 dev = [
     "pytest",  # 用于测试
     "ruff",    # 用于代码检查和格式化
-    "black",   
+    "black",
+    "pre-commit"
 ]
 
 win = [
     "pytest",  # 用于测试
     "ruff",    # 用于代码检查和格式化
     "black",
-    "pywin32"  
+    "pywin32",
+    "pre-commit"
 ]
 
 [tool.setuptools]
@@ -58,10 +60,12 @@ target-version = ['py38']
 [tool.ruff]
 target-version = "py38"
 line-length = 88
+
+[tool.ruff.lint]
 select = ["E", "F", "W", "I"]
 ignore = ["E501","E722"]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = ["src"]
 
 [tool.pytest.ini_options]

--- a/script/check_dirty.py
+++ b/script/check_dirty.py
@@ -1,0 +1,21 @@
+import sys
+import subprocess
+
+# Check for tracked files that are modified but NOT staged
+result = subprocess.run(['git', 'diff', '--name-only'], capture_output=True, text=True)
+if result.stdout:
+    print("ERROR: Found tracked files with modifications that have not been staged (`git add`).", file=sys.stderr)
+    print("Please stage your changes before committing:", file=sys.stderr)
+    print(result.stdout.strip(), file=sys.stderr)
+    sys.exit(1)
+
+# Check for untracked files
+result = subprocess.run(['git', 'ls-files', '--others', '--exclude-standard', '--directory'], capture_output=True, text=True)
+if result.stdout:
+    print("ERROR: Untracked files detected. Please add them to .gitignore or commit them.", file=sys.stderr)
+    print("Untracked files:", file=sys.stderr)
+    print(result.stdout.strip(), file=sys.stderr)
+    sys.exit(1)
+
+# If no dirty state is found, allow the commit to proceed
+sys.exit(0)


### PR DESCRIPTION
@zxkjack123 @Valtro1s 

Closes https://github.com/asipp-neutronics/tricys/issues/37

### 主要修改如下：

1. 新增pre-commit hooks，包括commit前检查工作区状态以及python代码规范格式化

2. 添加`pyporject.toml`中pre-commit依赖关系以及修改`Makefile.bat`快捷指令

- `Makefile.bat win-install`：安装tricys以及配置pre-commit hooks
- `Makefile.bat uninstall`：卸载tricys
- `Makefile.bat reinstall`：重新安装tricys

### 测试方法：
1. 拉取该PR分支

2. `Makefile.bat reinstall`：重新安装tricys

3. `git commit`：测试提交commit

4. 效果如下：会次调用三个hooks，`check ... files` , `black` , `ruff` 

![55de369fcc020c362c95715cfc71b34b.png](https://i.mji.rip/2025/08/29/55de369fcc020c362c95715cfc71b34b.png)

### 注意事项：

- 若因为代码格式化调用失败，并且`black`和`ruff`工具能够自动修复则再次git commit即可，若无法自动修复则需要手动进行代码规范格式化后再次git commit。

- 若因为`check ... files`失败，则需要保证commit时工作区干净，可以选择添加.gitignore，删除文件，stash文件后再次git commit。